### PR TITLE
make lesson suitable for teaching with locally-built (serverless) pages

### DIFF
--- a/_extras/about.md
+++ b/_extras/about.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: About
-permalink: /about/
 ---
 {% include carpentries.html %}

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: Discussion
-permalink: /discuss/
 ---
 FIXME

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -1,4 +1,6 @@
-
+---
+title: Instructors' Notes
+---
 
 ## Setup
 
@@ -11,7 +13,7 @@ There is a seperate file for the setiup instructions for installing the various 
 ## The datasets used
 
 The data from the SN7577 dataset is used. It has been placed into an SQLite database called SN7577.SQLite.
-The data dictionary file for SN7577 is also referenced 'audit_of_political_engagement_11_ukda_data_dictionary.docx'. 
+The data dictionary file for SN7577 is also referenced 'audit_of_political_engagement_11_ukda_data_dictionary.docx'.
 The SN7577.tab and SN7577_Text.csv files are used when creating tables. All of the files are in the single [SQL_data.zip](../data/SQL_data.zip) file.
 
 The SN7577.SQLite database file will need to be downloaded to the local machine before it can be opened by DB Browser.
@@ -44,7 +46,7 @@ Making use of the available data dictionary information.
 
 [Creating new columns](../_episodes/05-creating-new-columns.md)
 
-This episode cover the creation of new columns as part of a query. 
+This episode cover the creation of new columns as part of a query.
 New columns are created from existing columns using builtin functions.
 Changing datatypes of columns using `cast` is described along with how different datatypes appear in the plugin.
 Both variants of the `case` statement are covered; to decide a value based on a decision and to allocate a value to a 'bin'.
@@ -82,13 +84,13 @@ How to automate a script is covered.
 
 The need for table joins is discussed
 The different types of joins is discussed and why you may need to do more than just inner joins to investigate your data.
-There are examples of usingthe `join` and `on` SQL syntax. 
+There are examples of usingthe `join` and `on` SQL syntax.
 There is more discussion on Alias'.
 
 [Using database tables in other environments](../_episodes/10-other-environments.md)
 
 The episode requires that the ODBC driver has been installed.  It could be done as an Instructor demo only, but obviously that is not so much fun for the students.
-The purpose and use of connection strings is covered 
+The purpose and use of connection strings is covered
 There is a detailed demonstration of using ODBC from Excel to connect to the SN7577 database. It doesn't matter what table is used.
 There are code only examples from R and Python. The aim is to emphasise the connection process and sending the query for execution rather than the code itself.
 The code could be run in appropriate environments, but the database location would have to be changed.

--- a/index.md
+++ b/index.md
@@ -1,11 +1,12 @@
 ---
 layout: lesson
 root: .
+permalink: index.html
 ---
 
-This is an alpha lesson to teach Data Management with SQL for Social Scientists, 
+This is an alpha lesson to teach Data Management with SQL for Social Scientists,
 We welcome and criticism, or error; and will take your feedback into account to
-improve both the presentation and the content. 
+improve both the presentation and the content.
 
 Databases are useful for both storing and using data effectively. Using a
 relational database serves several purposes.


### PR DESCRIPTION
See discussion here for more background: https://github.com/datacarpentry/datacarpentry.github.io/issues/542

In short, some Carpentries lessons use the path `/guide/` for their Instructor Notes page and others use `/guide/index.html` (the default defined in `_config.yml`). This PR removes permalinks with a trailing slash from the YAML front matter of the other Extras files, consistent with new lessons created with [the lesson template](https://github.com/carpentries/styles/), and _adds_ front matter to the Instructors' Notes page (`_extras/guide.md`) so it appears in the Extras dropdown etc. Although there's no functional difference in the online versions of the lesson pages, pages with a trailing slash in the permalink will result in **broken links in the version of the lesson built locally**. We'd like local builds to be usable e.g. in workshops taking place at locations with limited or unreliable Internet access. 

Keeping the paths to these files consistent will also help us avoid broken links on the [Data Carpentry Lessons page](https://datacarpentry.org/lessons/), and ensure that equivalent paths in new lessons created with the template are consistent with previously-developed lessons like this one.

I did a sweep through the lesson and found no internal links that needed adjusting as part of this PR. If and when this is merged, I'll also make sure the link on https://datacarpentry.org/lessons/ to the Instructor Notes page isn't broken, and make another sweep through the lesson pages too, in case I missed something. 

Finally, I also removed the `layout` field from several pages, as the default layout is already set for Episodes and Extras pages in `_config.yml`.