### PR TITLE
Fixed typo code-coding a `NULL` in episode 4

### DIFF
--- a/_episodes/04-missing-data.md
+++ b/_episodes/04-missing-data.md
@@ -103,7 +103,7 @@ WHERE F14_items_owned is NULL
 
 Rather than changing the data we may just want to miss it out of our analysis.
 
-We can write a query which excludes the rows where `F14_items_owned` has a `NULL value with:
+We can write a query which excludes the rows where `F14_items_owned` has a `NULL` value with:
 
 ~~~
 SELECT * from Farms


### PR DESCRIPTION
The closing backtick was missing

Patch 3 of 8 (sorry I couldn't see how to put them all in one pull request)