### PR TITLE
add .zenodo.json file for lesson release

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,50 @@
+{
+  "contributors": [],
+  "creators": [
+    {
+      "name": "Peter Smyth"
+    },
+    {
+      "name": "Matthias Bussonnier"
+    },
+    {
+      "name": "Phil Reed",
+      "orcid": "0000-0002-4479-715X"
+    },
+    {
+      "name": "Tracy Teal",
+      "orcid": "0000-0002-9180-9598"
+    },
+    {
+      "name": "David Mawdsley"
+    },
+    {
+      "name": "Kunal Marwaha",
+      "orcid": "0000-0001-9084-6971"
+    },
+    {
+      "name": "Peter Kiraly"
+    },
+    {
+      "name": "Addi Malviya Thakur"
+    },
+    {
+      "name": "Juan Fung",
+      "orcid": "0000-0002-0820-787X"
+    },
+    {
+      "name": "Karen Word",
+      "orcid": "0000-0002-7294-7231"
+    },
+    {
+      "name": "Katrin Leinweber",
+      "orcid": "0000-0001-5135-5758"
+    },
+    {
+      "name": "Maneesha Sane"
+    }
+  ],
+  "license": {
+    "id": "CC-BY-4.0"
+  }
+}


### PR DESCRIPTION
Adds a `.zenodo.json` with metadata about contributors, in preparation for the infrastructure transition.