### PR TITLE
Update slack links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://swc-slack-invite.herokuapp.com/)
-[![Slack Status](https://img.shields.io/badge/Slack_Channel-dc--socsci--sql-E01563.svg)](https://swcarpentry.slack.com/messages/C9Y6QJZ8F)
+[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://slack-invite.carpentries.org/)
+[![Slack Status](https://img.shields.io/badge/Slack_Channel-dc--socsci--sql-E01563.svg)](https://carpentries.slack.com/messages/C9Y6QJZ8F)
 
 # sql-socialsci
 


### PR DESCRIPTION
The Carpentries recently updated their Slack domain URL and invite app URL. This PR updates the links to match the new domains.
